### PR TITLE
add candidate visuals with stellarium params

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { ExplorerMode } from "@/components/explorer-mode"
 import { ResearcherMode } from "@/components/researcher-mode"
 import { UploadMode } from "@/components/upload-mode"
 import { LightCurveChart } from "@/components/light-curve-chart"
+import { CandidateVisuals } from "@/components/candidate-visuals"
 import type { GlobalControls, PredictionResult } from "@/lib/types"
 
 export default function Home() {
@@ -78,6 +79,10 @@ export default function Home() {
                 transitEvents={result.transitEvents}
                 title={`Light Curve: ${result.targetId}`}
               />
+            )}
+
+            {result && (
+              <CandidateVisuals targetId={result.targetId} />
             )}
 
             {result ? (

--- a/src/components/candidate-visuals.tsx
+++ b/src/components/candidate-visuals.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { useState, useEffect } from "react"
+
+interface CandidateVisualsProps {
+  targetId: string
+}
+
+export function CandidateVisuals({ targetId }: CandidateVisualsProps) {
+  const [stellariumUrl, setStellariumUrl] = useState<string>("")
+
+  useEffect(() => {
+    // Parse target ID to Stellarium format (remove hyphens, keep spaces)
+    const getStarIdentifier = (id: string): string => {
+      const trimmed = id.trim().toUpperCase()
+      // Simply replace hyphens with spaces for Stellarium format
+      // KOI-123.01 → "KOI 123.01"
+      // KIC-12345678 → "KIC 12345678"
+      return trimmed.replace(/-/g, " ")
+    }
+
+    const starId = getStarIdentifier(targetId)
+
+    // Stellarium Web URL with object search and parameters
+    // Format: https://stellarium-web.org/skysource/{object_name}
+    const encodedStar = encodeURIComponent(starId)
+
+    // Add URL parameters:
+    // - fov=0.25 for 400% zoom (smaller field of view = more zoomed in)
+    // - atmosphere=false to disable atmosphere
+    // - landscape=false to disable ground/horizon
+    // - hide_panel=true to close left navigation panel
+    const url = `https://stellarium-web.org/skysource/${encodedStar}?fov=0.25&atmosphere=false&landscape=false&hide_panel=true`
+
+    setStellariumUrl(url)
+  }, [targetId])
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Candidate Visuals: {targetId}</CardTitle>
+          <Badge variant="secondary" className="text-xs">
+            Stellarium Sky View
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="relative w-full h-[400px] rounded-lg overflow-hidden border border-border">
+          {stellariumUrl ? (
+            <iframe
+              src={stellariumUrl}
+              className="w-full h-full"
+              title={`Stellarium view of ${targetId}`}
+              allow="fullscreen"
+              style={{ border: 0 }}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-full bg-card">
+              <p className="text-sm text-muted-foreground">Loading sky view...</p>
+            </div>
+          )}
+        </div>
+        <div className="mt-3 text-xs text-muted-foreground">
+          <p>Interactive 3D sky view powered by Stellarium. Use mouse to navigate.</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/explorer-mode.tsx
+++ b/src/components/explorer-mode.tsx
@@ -50,11 +50,11 @@ export function ExplorerMode({ controls, onResultsChange, onLoadingChange }: Exp
     // KOI format: KOI-123 or KOI-123.01
     const koiPattern = /^KOI-\d+(\.\d+)?$/
     // KIC format: KIC-12345678
-    const kicPattern = /^KIC-?\d{8,9}$/
+    const kicPattern = /^KIC-?\d{7,9}$/
     // EPIC format: EPIC-12345678
-    const epicPattern = /^EPIC-?\d{8,9}$/
+    const epicPattern = /^EPIC-?\d{7,9}$/
     // TIC format: TIC-12345678
-    const ticPattern = /^TIC-?\d{8,10}$/
+    const ticPattern = /^TIC-?\d{7,10}$/
 
     return koiPattern.test(trimmed) || kicPattern.test(trimmed) || epicPattern.test(trimmed) || ticPattern.test(trimmed)
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Adds an interactive sky view for candidate targets in the results panel, shown alongside existing charts and details. Displays a loading indicator until ready and appears only when results are available.
* Improvements
  * Expands accepted target ID formats: KIC and EPIC now allow 7–9 digits; TIC allows 7–10 digits. KOI handling unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->